### PR TITLE
fix: process is not defined in browser environment (#806)

### DIFF
--- a/lib/utils/log.ts
+++ b/lib/utils/log.ts
@@ -1,4 +1,3 @@
 /*eslint no-console:0*/
-export default function log(...args: unknown[]): void {
-  if (process.env.DRAGGABLE_DEBUG) console.log(...args);
-}
+const log = typeof process !== 'undefined' && process.env.DRAGGABLE_DEBUG ? console.log.bind(console) : function noop(): void {};
+export default log;


### PR DESCRIPTION
Fix #806 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug logging behavior so it safely handles environments where `process` is unavailable.
  * Logging now consistently falls back to a no-op when debug mode is not enabled, reducing unnecessary output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->